### PR TITLE
Set env variable AIRFLOW_GPL_UNIDECODE=yes when installing airflow

### DIFF
--- a/cloudformation/airflow.yaml
+++ b/cloudformation/airflow.yaml
@@ -92,11 +92,11 @@ Resources:
          sudo pip install boto3
          # Install airflow using pip
          echo "Install Apache Airflow"
-         sudo pip install apache-airflow
+         sudo AIRFLOW_GPL_UNIDECODE=yes pip install apache-airflow
          # Encrypt connection passwords in metadata db
-         sudo pip install apache-airflow[crypto]
+         sudo AIRFLOW_GPL_UNIDECODE=yes pip install apache-airflow[crypto]
          # Postgres operators and hook, support as an Airflow backend
-         sudo pip install apache-airflow[postgres]
+         sudo AIRFLOW_GPL_UNIDECODE=yes pip install apache-airflow[postgres]
          sudo -H pip install six==1.10.0
          sudo pip install --upgrade six
          sudo pip install markupsafe


### PR DESCRIPTION
Avoids 
`RuntimeError: By default one of Airflow's dependencies installs a GPL dependency (unidecode). To avoid this dependency set SLUGIFY_USES_TEXT_UNIDECODE=yes in your environment when you install or upgrade Airflow. To force installing the GPL version set AIRFLOW_GPL_UNIDECODE`
when running `sudo pip install apache-airflow`

*Issue #1*

*Description of changes: In airflow.yaml.Resources.EC2Instance.Properties.UserData, changed `sudo pip install apache-ariflow` to `sudo AIRFLOW_GPL_UNIDECODE=yes pip install apache-airflow`, same to apache-airflow[crypto] and apache-airflow[postgres]*
